### PR TITLE
Changed the suggrested API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that the monetary values in the pricing.json file are in pennies GBP and th
 
 In this hypothetical universe we've decided to launch tails.com overseas, and want the pricing service to be able to return equivalent prices in any given currency using the latest available exchange rate data.
 
-Expand the API to allow the currency to be passed in as part of the request, and return the equivalent price in that currency. How that currency code is passed in is up to you. Use a currency conversion rate API like [fixer.io](http://fixer.io) to get the latest exchange rates as part of your solution. (Hint: you might want to think about how to cache that data).
+Expand the API to allow the currency to be passed in as part of the request, and return the equivalent price in that currency. How that currency code is passed in is up to you. Use a currency conversion rate API like [https://free.currencyconverterapi.com/](https://free.currencyconverterapi.com/) to get the latest exchange rates as part of your solution. (Hint: you might want to think about how to cache that data).
 
 For the purposes of the test, assume the same VAT rates apply to all countries and currencies. (If the world actually worked this way, I think I'd still have hair on my head.)
 


### PR DESCRIPTION
So, it turns out that fixer.io now requires an API key, which in turn requires signup etc.
Since the point of the test is not to find out if candidates are willing to signup to
an API, but rather to see if they can read the docs, find a client library or something
similar, it seems prudent to change our suggestion of API so that it's simpler for candidates
to get the real purpose of the challenge.

I've updated the readme to a different suggested API, which *should* do the job