### PR TITLE
Improving clarity of instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,24 @@ information for the order:
 
 ```json
 {
-	"order": {
-		"id": 12345,
-		"customer": {
-			...
-		},
-		"items": [
-			{
-				"product_id": 1,
-				"quantity": 1
-			},
-			{
-				"product_id": 2,
-				"quantity": 5
-			},
-			{
-				"product_id": 3,
-				"quantity": 1
-			}
-		]
-	}
+    "order": {
+        "id": 12345,
+        "customer": {},
+        "items": [
+            {
+                "product_id": 1,
+                "quantity": 1
+            },
+            {
+                "product_id": 2,
+                "quantity": 5
+            },
+            {
+                "product_id": 3,
+                "quantity": 1
+            }
+        ]
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # Coding Test: Pricing Service
 
-Thank you for taking the time to complete our coding test. Your challenge is to recreate a hypothetical version of our internal pricing service. 
+Thank you for taking the time to complete our coding test. Your challenge is to
+recreate a hypothetical version of our internal pricing service. 
 
-You're free to use the language, frameworks and/or libraries of your choice, but through this test we want to see how you think about and solve problems in code so make sure there's a decent chunk of your own code in there.
+You are free to use the language, frameworks and/or libraries of your choice, 
+but through this test we want to see how you think about and solve problems in 
+code so make sure there's a decent chunk of your own code in there.
 
-Feel free to **spend as much or as little time as you'd like** as long as the specified functionality is complete. As a ballpark, the test should take around 90 minutes of development time.
+Feel free to **spend as much or as little time as you'd like** as long as the 
+specified functionality is complete. As a ballpark, the test should take around
+90 minutes of development time.
 
 
-## Building the basic API
+## Building the API
 
-Given the included [pricing data](./pricing.json), build a RESTful API endpoint that will accept requests like the one shown below and return pricing information for the order:
+Given the included [pricing data](./pricing.json), build a RESTful API endpoint
+that will accept requests like the one shown below and return pricing
+information for the order:
 
 ```json
 {
@@ -40,32 +47,47 @@ The returned data structure should include:
 
 * the total price for the order
 * the total VAT for the order
-* price and VAT for each item in the order
+* the price and VAT for each item in the order
 
 Data structure for the response is up to you.
 
-Note that the monetary values in the pricing.json file are in pennies GBP and the results should be likewise. Any rounding should use standard arithmetic rounding to the nearest penny.
+All monetary values in the `pricing.json` file are in pennies (pound sterling, `GBP`).
+The calculated results should be in pennies too.
+Any rounding should use standard arithmetic rounding to the nearest penny.
 
 
 ## Going international
 
-In this hypothetical universe we've decided to launch tails.com overseas, and want the pricing service to be able to return equivalent prices in any given currency using the latest available exchange rate data.
+In this hypothetical universe we've decided to launch tails.com overseas, and 
+want the pricing service to be able to return equivalent prices in any given 
+currency using the latest available exchange rate data.
 
-Expand the API to allow the currency to be passed in as part of the request, and return the equivalent price in that currency. How that currency code is passed in is up to you. Use a currency conversion rate API like [https://free.currencyconverterapi.com/](https://free.currencyconverterapi.com/) to get the latest exchange rates as part of your solution. (Hint: you might want to think about how to cache that data).
+Expand the API to allow the currency to be passed in as part of the request, 
+and return the equivalent price in that currency. How that currency code is 
+passed in is up to you. Use a currency conversion rate API like 
+[https://free.currencyconverterapi.com/](https://free.currencyconverterapi.com/) 
+to get the latest exchange rates as part of your solution. (Hint: you might 
+want to think about how to cache that data).
 
-For the purposes of the test, assume the same VAT rates apply to all countries and currencies. (If the world actually worked this way, I think I'd still have hair on my head.)
+For the purposes of the test, assume the same VAT rates apply to all countries 
+and currencies.
 
 
 ## Testing
 
-If you haven't been doing so as you've gone along, write appropriate tests in the test framework of choice for the pricing logic. If you don't have time, just tell us how you'd go about testing that this logic works as intended (e.g. what level of testing, what sorts of test cases, etc.).
+If you haven't been doing so as you've gone along, write appropriate tests in 
+the test framework of choice for the pricing logic. If you don't have time, 
+just tell us how you'd go about testing that this logic works as intended 
+(e.g. what level of testing, what sorts of test cases, etc.).
 
 
 ## Submitting
 
-Once you're happy with your code, zip it up and email it back to us along with answers to the following questions:
+Once you are happy with your code, zip it up and email it back to us along with 
+answers to the following questions:
 
-1. What command do we run to start your server? 
+1. What command(s) do we run to install and start your server?
 2. If you had more time, what improvements would you make if any?
-3. What bits did you find the toughest? What bit are you most proud of? In both cases, why?
+3. What bits did you find the toughest? What bit are you most proud of? In both
+   cases, why?
 4. What one thing could we do to improve this test?

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ currency using the latest available exchange rate data.
 Expand the API to allow the currency to be passed in as part of the request, 
 and return the equivalent price in that currency. How that currency code is 
 passed in is up to you. Use a currency conversion rate API like 
-[https://free.currencyconverterapi.com/](https://free.currencyconverterapi.com/) 
+[free.currencyconverterapi.com](https://free.currencyconverterapi.com/) 
 to get the latest exchange rates as part of your solution. (Hint: you might 
 want to think about how to cache that data).
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Thank you for taking the time to complete our coding test. Your challenge is to
 recreate a hypothetical version of our internal pricing service. 
 
-You are free to use the language, frameworks and/or libraries of your choice, 
-but through this test we want to see how you think about and solve problems in 
-code so make sure there's a decent chunk of your own code in there.
+You can use any language, framework and/or library for this test. We want to 
+see how you think about and solve problems in code, so make sure there is a 
+decent chunk of your own code in there.
 
 Feel free to **spend as much or as little time as you'd like** as long as the 
 specified functionality is complete. As a ballpark, the test should take around
@@ -14,9 +14,8 @@ specified functionality is complete. As a ballpark, the test should take around
 
 ## Building the API
 
-Given the included [pricing data](./pricing.json), build a RESTful API endpoint
-that will accept requests like the one shown below and return pricing
-information for the order:
+Using the [pricing data](./pricing.json), build a RESTful API endpoint that 
+accepts requests like the one below.
 
 ```json
 {
@@ -41,7 +40,7 @@ information for the order:
 }
 ```
 
-The returned data structure should include:
+The endpoint should return a data structure which includes:
 
 * the total price for the order
 * the total VAT for the order
@@ -56,13 +55,15 @@ Any rounding should use standard arithmetic rounding to the nearest penny.
 
 ## Going international
 
-In this hypothetical universe we've decided to launch tails.com overseas, and 
-want the pricing service to be able to return equivalent prices in any given 
-currency using the latest available exchange rate data.
+In this hypothetical universe we have decided to launch tails.com overseas. We 
+now want the pricing service to return prices in any currency. Those prices 
+should be calculated using the latest available exchange rate.
 
-Expand the API to allow the currency to be passed in as part of the request, 
-and return the equivalent price in that currency. How that currency code is 
-passed in is up to you. Use a currency conversion rate API like 
+Expand the API to allow a currency to be submitted as part of the request, and 
+return the prices in that currency. How that currency code is passed in is up 
+to you. 
+
+Use a currency conversion rate API like 
 [free.currencyconverterapi.com](https://free.currencyconverterapi.com/) 
 to get the latest exchange rates as part of your solution. (Hint: you might 
 want to think about how to cache that data).
@@ -73,10 +74,12 @@ and currencies.
 
 ## Testing
 
-If you haven't been doing so as you've gone along, write appropriate tests in 
-the test framework of choice for the pricing logic. If you don't have time, 
-just tell us how you'd go about testing that this logic works as intended 
-(e.g. what level of testing, what sorts of test cases, etc.).
+We would like to see some tests written in the testing framework of your choice
+for the pricing logic. 
+
+If you do not have time to write tests, tell us how you
+would test the pricing logic works as intended. For example: what level of 
+testing, what sorts of test cases, etc.
 
 
 ## Submitting


### PR DESCRIPTION
Small pull request to improve the clarity of the instructions, specifically around using pennies and the need for installation instructions to be supplied.

Also tweaked the line lengths in the `README.md` to improve readability without wrapping enabled.